### PR TITLE
Ian condition category test fail due to Ethercis not returning 204 error for empty query result

### DIFF
--- a/src/test/java/com/inidus/platform/fhir/condition/ConditionProviderTest.java
+++ b/src/test/java/com/inidus/platform/fhir/condition/ConditionProviderTest.java
@@ -27,8 +27,8 @@ public class ConditionProviderTest {
 
     @Before
     public void setUp() throws Exception {
-        //     configureCdrConnector("http://178.62.71.220:8080", "guest", "guest", true);
-        configureCdrConnector("https://test.operon.systems", "oprn_hcbox", "XioTAJoO479", true);
+             configureCdrConnector("http://178.62.71.220:8080", "guest", "guest", true);
+       // configureCdrConnector("https://test.operon.systems", "oprn_hcbox", "XioTAJoO479", true);
     }
 
     @Test
@@ -98,7 +98,8 @@ public class ConditionProviderTest {
 
         List<ConditionCC> result = testProvider.getFilteredResources(null, null, category, null, null);
 
-        Assert.assertNull(result);
+        //Check for isEmtpoy as EtherCis returns an empty array rather than a 204 error
+        Assert.assertTrue((null == result) || result.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #14   - failing test In Condition for Ethercis which was due to Ethercis returning an empty resultset array, rather than 204 error when the query result is empty. The test code has been updated to test for empty array and nulls.

Condition test now passing on Ethercis.