### PR TITLE
Fixed failing Date Search test in ConditionProvider due to Ethercis n…

### DIFF
--- a/src/main/java/com/inidus/platform/fhir/condition/ConditionConnector.java
+++ b/src/main/java/com/inidus/platform/fhir/condition/ConditionConnector.java
@@ -93,13 +93,13 @@ public class ConditionConnector extends OpenEhrConnector {
         Date fromDate = conditionAsserted.getLowerBoundAsInstant();
         if (null != fromDate) {
             String from = ISO_DATE.format(fromDate);
-            filter += String.format(" and a/context/start_time/value >= '%s'", from);
+            filter += String.format(" and b_a/protocol[at0032]/items[at0070]/value/value >= '%s'", from);
         }
 
         Date toDate = conditionAsserted.getUpperBoundAsInstant();
         if (null != toDate) {
             String to = ISO_DATE.format(toDate);
-            filter += String.format(" and a/context/start_time/value <= '%s'", to);
+            filter += String.format(" and b_a/protocol[at0032]/items[at0070]/value/value <= '%s'", to);
         }
         return filter;
     }


### PR DESCRIPTION
This fixes the Date Search ConditionProvider tests fail due to incorrect EtherCis date handling on composition/start_date/value.

Now searching on AssertedDate, which is probably a more accurate target in any case.

All tests now passing locally.