### PR TITLE
Adjusted AQL to use Scalar approach to retrieving CodeableConcepts as…

### DIFF
--- a/src/main/java/com/inidus/platform/fhir/allergy/AllergyConnector.java
+++ b/src/main/java/com/inidus/platform/fhir/allergy/AllergyConnector.java
@@ -29,7 +29,9 @@ public class AllergyConnector extends OpenEhrConnector {
                 " a/composer/external_ref/namespace as composerNamespace," +
                 " b_a/uid/value as entryId," +
                 " b_a/protocol[at0042]/items[at0062]/value/value as AssertedDate," +
-                " b_a/data[at0001]/items[at0002] as Causative_agent," +
+                " b_a/data[at0001]/items[at0002]/value/value as Causative_agent_value," +
+                " b_a/data[at0001]/items[at0002]/value/defining_code/code_string as Causative_agent_code," +
+                " b_a/data[at0001]/items[at0002]/value/defining_code/terminology_id/value as Causative_agent_terminology," +
                 " b_a/data[at0001]/items[at0063]/value/defining_code/code_string as Status_code," +
                 " b_a/data[at0001]/items[at0101]/value/defining_code/code_string as Criticality_code," +
                 " b_a/data[at0001]/items[at0120]/value/defining_code/code_string as Category_code," +

--- a/src/main/java/com/inidus/platform/fhir/condition/ConditionConnector.java
+++ b/src/main/java/com/inidus/platform/fhir/condition/ConditionConnector.java
@@ -29,8 +29,12 @@ public class ConditionConnector extends OpenEhrConnector {
                 " a/composer/external_ref/id/value as composerId," +
                 " a/composer/external_ref/namespace as composerNamespace," +
                 " b_a/uid/value as entryId," +
-                " b_a/data[at0001]/items[at0002] as Problem_Diagnosis," +
-                " b_a/data[at0001]/items[at0012] as Body_site," +
+                " b_a/data[at0001]/items[at0002]/value/value as Problem_Diagnosis_value," +
+                " b_a/data[at0001]/items[at0002]/value/defining_code/code_string as Problem_Diagnosis_code," +
+                " b_a/data[at0001]/items[at0002]/value/defining_code/terminology_id/value as Problem_Diagnosis_terminology," +
+                " b_a/data[at0001]/items[at0012]/value/value as Body_site_value," +
+                " b_a/data[at0001]/items[at0012]/value/defining_code/code_string as Body_site_code," +
+                " b_a/data[at0001]/items[at0012]/value/defining_code/terminology_id/value as Body_site_terminology," +
                 " b_a/data[at0001]/items[at0077]/value/value as Date_time_of_onset," +
                 " b_a/data[at0001]/items[at0030]/value/value as Date_time_of_resolution," +
                 " b_a/data[at0001]/items[at0005]/value/defining_code/code_string as Severity_code," +

--- a/src/main/java/com/inidus/platform/fhir/medication/MedicationStatementConnector.java
+++ b/src/main/java/com/inidus/platform/fhir/medication/MedicationStatementConnector.java
@@ -31,7 +31,9 @@ public class MedicationStatementConnector extends OpenEhrConnector {
                 "  a/composer/external_ref/id/value as composerId," +
                 "  a/composer/external_ref/namespace as composerNamespace," +
                 "  b_a/uid/value as entryId," +
-                "  b_a/activities[at0001]/description[at0002]/items[at0070] as Medication_item," +
+                "  b_a/activities[at0001]/description[at0002]/items[at0070]/value/value as Medication_item_value," +
+                "  b_a/activities[at0001]/description[at0002]/items[at0070]/value/defining_code/code_string as Medication_item_code," +
+                "  b_a/activities[at0001]/description[at0002]/items[at0070]/value/defining_code/terminology_id/value as Medication_item_terminology," +
                 "  b_a/activities[at0001]/description[at0002]/items[at0009]/value/value as Overall_directions_description," +
                 "  b_a/activities[at0001]/description[at0002]/items[at0173, 'Dose amount description']/value/value as Dose_amount_description," +
                 "  b_a/activities[at0001]/description[at0002]/items[at0173, 'Dose timing description']/value/value as Dose_timing_description," +

--- a/src/main/java/com/inidus/platform/fhir/procedure/ProcedureConnector.java
+++ b/src/main/java/com/inidus/platform/fhir/procedure/ProcedureConnector.java
@@ -30,12 +30,22 @@ public class ProcedureConnector extends OpenEhrConnector {
                 "   a/composer/external_ref/id/value as composerId,\n" +
                 "   a/composer/external_ref/namespace as composerNamespace,\n" +
                 "   b_a/uid/value as entryId,\n" +
-                "   b_a/description[at0001]/items[at0002] as Procedure_name,\n" +
-                "   b_a/description[at0001]/items[at0048] as Outcome,\n" +
-                "   b_a/description[at0001]/items[at0006] as Complication,\n" +
+                "   b_a/description[at0001]/items[at0002]/value/value as Procedure_name_value,\n" +
+                "   b_a/description[at0001]/items[at0002]/value/defining_code/code_string as Procedure_name_code,\n" +
+                "   b_a/description[at0001]/items[at0002]/value/defining_code/terminology_id/value as Procedure_name_terminology,\n" +
+                "   b_a/description[at0001]/items[at0048]/value/value as Outcome_value,\n" +
+                "   b_a/description[at0001]/items[at0048]/value/defining_code/code_string as Outcome_code,\n" +
+                "   b_a/description[at0001]/items[at0048]/value/defining_code/terminology_id/value as Outcome_terminology,\n" +
+                "   b_a/description[at0001]/items[at0006]/value/value as Complication_value,\n" +
+                "   b_a/description[at0001]/items[at0006]/value/defining_code/code_string as Complication_code,\n" +
+                "   b_a/description[at0001]/items[at0006]/value/defining_code/terminology_id/value as Complication_terminology,\n" +
                 "   b_a/description[at0001]/items[at0067] as Procedure_type,\n" +
-                "   b_a/description[at0001]/items[at0063] as Body_site,\n" +
-                "   b_a/description[at0001]/items[at0014] as Reason,\n" +
+                "   b_a/description[at0001]/items[at0063]/value/value as Body_site_value,\n" +
+                "   b_a/description[at0001]/items[at0063]/value/defining_code/code_string as Body_site_code,\n" +
+                "   b_a/description[at0001]/items[at0063]/value/defining_code/terminology_id/value as Body_site_terminology,\n" +
+                "   b_a/description[at0001]/items[at0014]/value/value as Reason_value,\n" +
+                "   b_a/description[at0001]/items[at0014]/value/defining_code/code_string as Reason_code,\n" +
+                "   b_a/description[at0001]/items[at0014]/value/defining_code/terminology_id/value as Reason_terminology,\n" +
                 "   b_a/description[at0001]/items[at0005]/value/value as Comment,\n" +
                 "   b_a/other_participations as OtherParticipations,\n" +
                 "   b_a/time/value as Procedure_time,\n" +


### PR DESCRIPTION
Fixes #30  

… Ethercis still has some issues with support for the Object approach and returns escaped JSON - revert to using Scalar approach to dv_text/dv_coded_text objects

AQL for 

- AllergyIntolerance
- Procedure
- MedicationStatement
- Condition

adjusted to use scalar approach.
